### PR TITLE
[common,tools] Pass permissions for open call

### DIFF
--- a/include/aos/common/tools/fs.hpp
+++ b/include/aos/common/tools/fs.hpp
@@ -418,7 +418,7 @@ public:
             return err;
         }
 
-        auto fd = open(fileName.CStr(), O_CREAT | O_WRONLY);
+        auto fd = open(fileName.CStr(), O_CREAT | O_WRONLY, perm);
         if (fd < 0) {
             return Error(errno);
         }


### PR DESCRIPTION
This PR reverts recent change in the open function call that leads to compile error on yocto

In function ‘int open(const char*, int, ...)’,
    inlined from ‘static aos::Error aos::FS::WriteFile(const aos::String&, const aos::Array<unsigned char>&, uint32_t)’ at /home/mykhailo_lohvynenko/projects/aos/aos_core_lib_cpp/include/aos/common/tools/fs.hpp:421:23:
/opt/aos-vm-dev/4.0.21/sysroots/core2-64-aosvm-linux/usr/include/bits/fcntl2.h:50:31: error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments
   50 |           __open_missing_mode ();