### PR TITLE
[common,ocispec] Change content descriptor size type to uint64_t

### DIFF
--- a/include/aos/common/ocispec.hpp
+++ b/include/aos/common/ocispec.hpp
@@ -62,7 +62,7 @@ constexpr auto cMaxIRQsCount = AOS_CONFIG_OCISPEC_MAX_IRQS_COUNT;
 struct ContentDescriptor {
     StaticString<cMaxMediaTypeLen> mMediaType;
     StaticString<cMaxDigestLen>    mDigest;
-    int64_t                        mSize;
+    uint64_t                       mSize;
 
     /**
      * Compares content descriptor.


### PR DESCRIPTION
aos core zephyr will parse this field as JSON_TOK_UINT64.
This PR updates content descriptor type to uint64_t to fix compiler warnings for zephyr build.