### PR TITLE
Fix slot numbering

### DIFF
--- a/include/aos/common/tools/array.hpp
+++ b/include/aos/common/tools/array.hpp
@@ -457,6 +457,19 @@ public:
     StaticArray() { Array<T>::SetBuffer(mBuffer); }
 
     /**
+     * Creates static array with fixed size.
+     *
+     * @param size fixed size.
+     */
+    explicit StaticArray(size_t size)
+    {
+        Array<T>::SetBuffer(mBuffer);
+        auto err = Array<T>::Resize(size);
+
+        assert(err.IsNone());
+    }
+
+    /**
      * Creates static array from another static array.
      *
      * @param array array to create from.

--- a/include/aos/sm/servicemanager.hpp
+++ b/include/aos/sm/servicemanager.hpp
@@ -82,7 +82,8 @@ struct ServiceData {
     bool operator==(const ServiceData& data) const
     {
         return mServiceID == data.mServiceID && mProviderID == data.mProviderID && mVersion == data.mVersion
-            && mImagePath == data.mImagePath && mCached == data.mCached && mSize == data.mSize && mGID == data.mGID;
+            && mImagePath == data.mImagePath && data.mManifestDigest == mManifestDigest && mCached == data.mCached
+            && mSize == data.mSize && mGID == data.mGID;
     }
 
     /**


### PR DESCRIPTION
Previously, when a slot was removed, and a new slot was added, the new slot would receive a number already present in the container. For example, if there were two slots with numbers 0 and 1, and slot 0 was deleted, adding a new slot would incorrectly assign it the number 1, which was already in use.