### PR TITLE
[iam,provisionmanager] Move getting cert to CertProviderItf

### DIFF
--- a/include/aos/iam/certprovider.hpp
+++ b/include/aos/iam/certprovider.hpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef AOS_CERTPROVIDER_HPP_
+#define AOS_CERTPROVIDER_HPP_
+
+#include "aos/common/tools/error.hpp"
+#include "aos/iam/certhandler.hpp"
+
+namespace aos::iam::certprovider {
+
+/** @addtogroup iam Identification and Access Manager
+ *  @{
+ */
+
+/**
+ * Cert provider interface.
+ */
+class CertProviderItf {
+public:
+    /**
+     * Returns certificate info.
+     *
+     * @param certType certificate type.
+     * @param issuer issuer name.
+     * @param serial serial number.
+     * @param[out] resCert result certificate.
+     * @returns Error.
+     */
+    virtual Error GetCert(const String& certType, const Array<uint8_t>& issuer, const Array<uint8_t>& serial,
+        certhandler::CertInfo& resCert) const
+        = 0;
+
+    /**
+     * Subscribes certificates receiver.
+     *
+     * @param certType certificate type.
+     * @param certReceiver certificate receiver.
+     * @returns Error.
+     */
+    virtual Error SubscribeCertChanged(const String& certType, certhandler::CertReceiverItf& certReceiver) = 0;
+
+    /**
+     * Unsubscribes certificate receiver.
+     *
+     * @param certReceiver certificate receiver.
+     * @returns Error.
+     */
+    virtual Error UnsubscribeCertChanged(certhandler::CertReceiverItf& certReceiver) = 0;
+
+    /**
+     * Destroys cert provider.
+     */
+    virtual ~CertProviderItf() = default;
+};
+
+/**
+ * Cert provider.
+ */
+class CertProvider : public CertProviderItf {
+public:
+    /**
+     * Initializes cert provider.
+     *
+     * @param certHandler certificate handler.
+     * @returns Error.
+     */
+    Error Init(certhandler::CertHandlerItf& certHandler);
+
+    /**
+     * Returns certificate info.
+     *
+     * @param certType certificate type.
+     * @param issuer issuer name.
+     * @param serial serial number.
+     * @param[out] resCert result certificate.
+     * @returns Error.
+     */
+    Error GetCert(const String& certType, const Array<uint8_t>& issuer, const Array<uint8_t>& serial,
+        certhandler::CertInfo& resCert) const override;
+
+    /**
+     * Subscribes certificates receiver.
+     *
+     * @param certType certificate type.
+     * @param certReceiver certificate receiver.
+     * @returns Error.
+     */
+    Error SubscribeCertChanged(const String& certType, certhandler::CertReceiverItf& certReceiver) override;
+
+    /**
+     * Unsubscribes certificate receiver.
+     *
+     * @param certReceiver certificate receiver.
+     * @returns Error.
+     */
+    Error UnsubscribeCertChanged(certhandler::CertReceiverItf& certReceiver) override;
+
+private:
+    certhandler::CertHandlerItf* mCertHandler {};
+};
+
+/** @} */ // end of iam group
+
+} // namespace aos::iam::certprovider
+
+#endif /* AOS_PROVISIONMANAGER_HPP_ */

--- a/include/aos/iam/provisionmanager.hpp
+++ b/include/aos/iam/provisionmanager.hpp
@@ -107,36 +107,6 @@ public:
     virtual Error ApplyCert(const String& certType, const String& pemCert, certhandler::CertInfo& certInfo) = 0;
 
     /**
-     * Returns certificate info.
-     *
-     * @param certType certificate type.
-     * @param issuer issuer name.
-     * @param serial serial number.
-     * @param[out] resCert result certificate.
-     * @returns Error.
-     */
-    virtual Error GetCert(const String& certType, const Array<uint8_t>& issuer, const Array<uint8_t>& serial,
-        certhandler::CertInfo& resCert) const
-        = 0;
-
-    /**
-     * Subscribes certificates receiver.
-     *
-     * @param certType certificate type.
-     * @param certReceiver certificate receiver.
-     * @returns Error.
-     */
-    virtual Error SubscribeCertChanged(const String& certType, certhandler::CertReceiverItf& certReceiver) = 0;
-
-    /**
-     * Unsubscribes certificate receiver.
-     *
-     * @param certReceiver certificate receiver.
-     * @returns Error.
-     */
-    virtual Error UnsubscribeCertChanged(certhandler::CertReceiverItf& certReceiver) = 0;
-
-    /**
      * Finishes provisioning.
      *
      * @param password password.
@@ -166,7 +136,6 @@ public:
     /**
      * Initializes provision manager.
      *
-     * @param certTypeConfigs certificate type configurations.
      * @param callback provision manager callback.
      * @param certHandler certificate handler.
      * @returns Error.
@@ -208,35 +177,6 @@ public:
      * @returns Error.
      */
     Error ApplyCert(const String& certType, const String& pemCert, certhandler::CertInfo& certInfo) override;
-
-    /**
-     * Returns certificate info.
-     *
-     * @param certType certificate type.
-     * @param issuer issuer name.
-     * @param serial serial number.
-     * @param[out] resCert result certificate.
-     * @returns Error.
-     */
-    Error GetCert(const String& certType, const Array<uint8_t>& issuer, const Array<uint8_t>& serial,
-        certhandler::CertInfo& resCert) const override;
-
-    /**
-     * Subscribes certificates receiver.
-     *
-     * @param certType certificate type.
-     * @param certReceiver certificate receiver.
-     * @returns Error.
-     */
-    Error SubscribeCertChanged(const String& certType, certhandler::CertReceiverItf& certReceiver) override;
-
-    /**
-     * Unsubscribes certificate receiver.
-     *
-     * @param certReceiver certificate receiver.
-     * @returns Error.
-     */
-    Error UnsubscribeCertChanged(certhandler::CertReceiverItf& certReceiver) override;
 
     /**
      * Finishes provisioning.

--- a/src/iam/CMakeLists.txt
+++ b/src/iam/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     certhandler/certhandler.cpp
     certmodules/certmodule.cpp
     certmodules/pkcs11/pkcs11.cpp
+    certprovider/certprovider.cpp
     identmodules/fileidentifier.cpp
     nodeinfoprovider/nodeinfoprovider.cpp
     nodemanager/nodemanager.cpp

--- a/src/iam/certprovider/certprovider.cpp
+++ b/src/iam/certprovider/certprovider.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Renesas Electronics Corporation.
+ * Copyright (C) 2024 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "aos/iam/certprovider.hpp"
+#include "log.hpp"
+
+namespace aos::iam::certprovider {
+
+/***********************************************************************************************************************
+ * Public
+ **********************************************************************************************************************/
+
+Error CertProvider::Init(certhandler::CertHandlerItf& certHandler)
+{
+    LOG_DBG() << "Init cert provider";
+
+    mCertHandler = &certHandler;
+
+    return aos::ErrorEnum::eNone;
+}
+
+Error CertProvider::GetCert(const String& certType, const Array<uint8_t>& issuer, const Array<uint8_t>& serial,
+    certhandler::CertInfo& resCert) const
+{
+    LOG_DBG() << "Get cert: type=" << certType;
+
+    return AOS_ERROR_WRAP(mCertHandler->GetCertificate(certType, issuer, serial, resCert));
+}
+
+Error CertProvider::SubscribeCertChanged(const String& certType, certhandler::CertReceiverItf& certReceiver)
+{
+    LOG_DBG() << "Subscribe cert receiver: type=" << certType;
+
+    return AOS_ERROR_WRAP(mCertHandler->SubscribeCertChanged(certType, certReceiver));
+}
+
+Error CertProvider::UnsubscribeCertChanged(certhandler::CertReceiverItf& certReceiver)
+{
+    LOG_DBG() << "Unsubscribe cert receiver";
+
+    return AOS_ERROR_WRAP(mCertHandler->UnsubscribeCertChanged(certReceiver));
+}
+
+} // namespace aos::iam::certprovider

--- a/src/iam/certprovider/log.hpp
+++ b/src/iam/certprovider/log.hpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (C) 2024 Renesas Electronics Corporation.
+ * Copyright (C) 2024 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef LOG_HPP_
+#define LOG_HPP_
+
+#define LOG_MODULE "certprovider"
+
+#include "aos/common/tools/logger.hpp"
+
+#endif

--- a/src/iam/provisionmanager/provisionmanager.cpp
+++ b/src/iam/provisionmanager/provisionmanager.cpp
@@ -132,26 +132,4 @@ Error ProvisionManager::ApplyCert(const String& certType, const String& pemCert,
     return AOS_ERROR_WRAP(mCertHandler->ApplyCertificate(certType, pemCert, certInfo));
 }
 
-Error ProvisionManager::GetCert(const String& certType, const Array<uint8_t>& issuer, const Array<uint8_t>& serial,
-    certhandler::CertInfo& resCert) const
-{
-    LOG_DBG() << "Get cert: type=" << certType;
-
-    return AOS_ERROR_WRAP(mCertHandler->GetCertificate(certType, issuer, serial, resCert));
-}
-
-Error ProvisionManager::SubscribeCertChanged(const String& certType, certhandler::CertReceiverItf& certReceiver)
-{
-    LOG_DBG() << "Subscribe cert receiver: type=" << certType;
-
-    return AOS_ERROR_WRAP(mCertHandler->SubscribeCertChanged(certType, certReceiver));
-}
-
-Error ProvisionManager::UnsubscribeCertChanged(certhandler::CertReceiverItf& certReceiver)
-{
-    LOG_DBG() << "Unsubscribe cert receiver";
-
-    return AOS_ERROR_WRAP(mCertHandler->UnsubscribeCertChanged(certReceiver));
-}
-
 } // namespace aos::iam::provisionmanager

--- a/tests/iam/CMakeLists.txt
+++ b/tests/iam/CMakeLists.txt
@@ -12,14 +12,15 @@ set(TARGET aosiamcpp_test)
 # ######################################################################################################################
 
 set(SOURCES
-    iam_test.cpp
     certmodules/certmodules_test.cpp
-    stubs/storagestub.cpp
+    certprovider/certprovider_test.cpp
     identmodules/fileidentifier_test.cpp
     nodeinfoprovider/nodeinfoprovider_test.cpp
+    nodemanager/nodemanager_test.cpp
     permhandler/permhandler_test.cpp
     provisionmanager/provisionmanager_test.cpp
-    nodemanager/nodemanager_test.cpp
+    stubs/storagestub.cpp
+    iam_test.cpp
 )
 
 # ######################################################################################################################

--- a/tests/iam/certprovider/certprovider_test.cpp
+++ b/tests/iam/certprovider/certprovider_test.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 Renesas Electronics Corporation.
+ * Copyright (C) 2024 EPAM Systems, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <gmock/gmock.h>
+
+#include <aos/iam/certprovider.hpp>
+
+#include "mocks/certhandlermock.hpp"
+#include "mocks/certreceivermock.hpp"
+
+using namespace testing;
+using namespace aos::iam;
+using namespace aos::iam::certprovider;
+
+/***********************************************************************************************************************
+ * Suite
+ **********************************************************************************************************************/
+
+class CertProviderTest : public testing::Test {
+protected:
+    void SetUp() override { mCertProvider.Init(mCertHandler); }
+
+    CertHandlerItfMock mCertHandler;
+    CertProvider       mCertProvider;
+};
+
+/***********************************************************************************************************************
+ * Tests
+ * **********************************************************************************************************************/
+
+TEST_F(CertProviderTest, GetCert)
+{
+    auto convertByteArrayToAosArray = [](const char* data, size_t size) -> aos::Array<uint8_t> {
+        return {reinterpret_cast<const uint8_t*>(data), size};
+    };
+
+    int64_t                         nowSec  = static_cast<int64_t>(time(nullptr));
+    int64_t                         nowNSec = 0;
+    aos::iam::certhandler::CertInfo certInfo;
+
+    certInfo.mIssuer   = convertByteArrayToAosArray("issuer", strlen("issuer"));
+    certInfo.mSerial   = convertByteArrayToAosArray("serial", strlen("serial"));
+    certInfo.mCertURL  = "certURL";
+    certInfo.mKeyURL   = "keyURL";
+    certInfo.mNotAfter = aos::Time::Unix(nowSec, nowNSec).Add(aos::Time::cYear);
+
+    EXPECT_CALL(mCertHandler, GetCertificate)
+        .WillOnce(DoAll(SetArgReferee<3>(certInfo), Return(aos::ErrorEnum::eNone)));
+
+    aos::iam::certhandler::CertInfo result;
+    ASSERT_TRUE(mCertProvider.GetCert("certType", certInfo.mIssuer, certInfo.mSerial, result).IsNone());
+    EXPECT_EQ(result, certInfo);
+}
+
+TEST_F(CertProviderTest, SubscribeCertChanged)
+{
+    const aos::String certType = "iam";
+
+    CertReceiverItfMock certReceiver;
+
+    EXPECT_CALL(mCertHandler, SubscribeCertChanged(certType, _)).WillOnce(Return(aos::ErrorEnum::eNone));
+    ASSERT_TRUE(mCertHandler.SubscribeCertChanged(certType, certReceiver).IsNone());
+
+    EXPECT_CALL(mCertHandler, UnsubscribeCertChanged(Ref(certReceiver))).WillOnce(Return(aos::ErrorEnum::eNone));
+    ASSERT_TRUE(mCertHandler.UnsubscribeCertChanged(certReceiver).IsNone());
+}

--- a/tests/iam/provisionmanager/provisionmanager_test.cpp
+++ b/tests/iam/provisionmanager/provisionmanager_test.cpp
@@ -10,7 +10,6 @@
 #include <aos/iam/provisionmanager.hpp>
 
 #include "mocks/certhandlermock.hpp"
-#include "mocks/certreceivermock.hpp"
 #include "mocks/provisioningcallbackmock.hpp"
 
 using namespace testing;
@@ -268,43 +267,6 @@ TEST_F(ProvisionManagerTest, ApplyCert)
 
     EXPECT_TRUE(err.IsNone()) << err.Message();
     EXPECT_EQ(certInfo, generatedCertInfo);
-}
-
-TEST_F(ProvisionManagerTest, GetCert)
-{
-    auto convertByteArrayToAosArray = [](const char* data, size_t size) -> aos::Array<uint8_t> {
-        return {reinterpret_cast<const uint8_t*>(data), size};
-    };
-
-    int64_t                         nowSec  = static_cast<int64_t>(time(nullptr));
-    int64_t                         nowNSec = 0;
-    aos::iam::certhandler::CertInfo certInfo;
-
-    certInfo.mIssuer   = convertByteArrayToAosArray("issuer", strlen("issuer"));
-    certInfo.mSerial   = convertByteArrayToAosArray("serial", strlen("serial"));
-    certInfo.mCertURL  = "certURL";
-    certInfo.mKeyURL   = "keyURL";
-    certInfo.mNotAfter = aos::Time::Unix(nowSec, nowNSec).Add(aos::Time::cYear);
-
-    EXPECT_CALL(mCertHandler, GetCertificate)
-        .WillOnce(DoAll(SetArgReferee<3>(certInfo), Return(aos::ErrorEnum::eNone)));
-
-    aos::iam::certhandler::CertInfo result;
-    ASSERT_TRUE(mProvisionManager.GetCert("certType", certInfo.mIssuer, certInfo.mSerial, result).IsNone());
-    EXPECT_EQ(result, certInfo);
-}
-
-TEST_F(ProvisionManagerTest, SubscribeCertChanged)
-{
-    const aos::String certType = "iam";
-
-    CertReceiverItfMock certReceiver;
-
-    EXPECT_CALL(mCertHandler, SubscribeCertChanged(certType, _)).WillOnce(Return(aos::ErrorEnum::eNone));
-    ASSERT_TRUE(mProvisionManager.SubscribeCertChanged(certType, certReceiver).IsNone());
-
-    EXPECT_CALL(mCertHandler, UnsubscribeCertChanged(Ref(certReceiver))).WillOnce(Return(aos::ErrorEnum::eNone));
-    ASSERT_TRUE(mProvisionManager.UnsubscribeCertChanged(certReceiver).IsNone());
 }
 
 TEST_F(ProvisionManagerTest, Deprovision)


### PR DESCRIPTION
It is not convenient to use ProvisionManagerItf to retrieve certs URL. Move that part to separate CertProviderItf.