### PR TITLE
[all] Add stack-usage (4096) warning for each target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ message(STATUS "WITH_DOC                      = ${WITH_DOC}")
 message(STATUS)
 
 # ######################################################################################################################
+# Config
+# ######################################################################################################################
+
+set(AOS_CORE_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+set(AOS_STACK_USAGE 4096)
+
+# ######################################################################################################################
 # Compiler flags
 # ######################################################################################################################
 
@@ -39,8 +46,6 @@ set(common_flags "-fPIC -Wall -Werror -Wextra -Wpedantic -Wno-format-truncation 
 set(CMAKE_CXX_FLAGS "${common_flags} ${CMAKE_CXX_FLAGS}")
 set(CMAKE_C_FLAGS "${common_flags} ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_STANDARD 17)
-
-set(AOS_CORE_LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 if(WITH_TEST)
     add_definitions(-include ${AOS_CORE_LIB_DIR}/include/aos/test/aoscoretestconfig.hpp)

--- a/include/aos/common/cloudprotocol/envvars.hpp
+++ b/include/aos/common/cloudprotocol/envvars.hpp
@@ -55,6 +55,18 @@ struct EnvVarsInstanceInfo {
     EnvVarInfoArray mVariables;
 
     /**
+     * Creates environment variable instance info.
+     *
+     * @param filter instance filter.
+     * @param variables environment variables.
+     */
+    EnvVarsInstanceInfo(const InstanceFilter& filter, const Array<EnvVarInfo>& variables)
+        : mFilter(filter)
+        , mVariables(variables)
+    {
+    }
+
+    /**
      * Compares environment variable instance info.
      *
      * @param info environment variable instance info to compare with.
@@ -108,6 +120,18 @@ using EnvVarStatusArray = StaticArray<EnvVarStatus, cMaxNumEnvVariables>;
 struct EnvVarsInstanceStatus {
     InstanceFilter    mFilter;
     EnvVarStatusArray mStatuses;
+
+    /**
+     * Creates environment variable instance status.
+     *
+     * @param filter instance filter.
+     * @param statuses environment variable statuses.
+     */
+    EnvVarsInstanceStatus(const InstanceFilter& filter, const Array<EnvVarStatus>& statuses)
+        : mFilter(filter)
+        , mStatuses(statuses)
+    {
+    }
 
     /**
      * Compares environment variable instance status.

--- a/include/aos/common/monitoring/average.hpp
+++ b/include/aos/common/monitoring/average.hpp
@@ -65,12 +65,16 @@ private:
         MonitoringData mMonitoringData;
     };
 
+    static constexpr auto cAllocatorSize = sizeof(AverageData);
+
     Error UpdateMonitoringData(MonitoringData& data, const MonitoringData& newData, bool& isInitialized);
     Error GetMonitoringData(MonitoringData& data, const MonitoringData& averageData) const;
 
     size_t                                                  mWindowCount = 0;
     AverageData                                             mAverageNodeData {};
     StaticMap<InstanceIdent, AverageData, cMaxNumInstances> mAverageInstancesData {};
+
+    StaticAllocator<cAllocatorSize> mAllocator;
 };
 
 } // namespace aos::monitoring

--- a/include/aos/common/monitoring/resourcemonitor.hpp
+++ b/include/aos/common/monitoring/resourcemonitor.hpp
@@ -106,6 +106,9 @@ public:
     Error ReceiveNodeConfig(const sm::resourcemanager::NodeConfig& nodeConfig) override;
 
 private:
+    static constexpr auto cAllocatorSize = Max(sizeof(NodeInfo) + sizeof(sm::resourcemanager::NodeConfig),
+        sizeof(InstanceMonitoringData) + sizeof(Array<AlertProcessor>));
+
     String                      GetParameterName(const ResourceIdentifier& id) const;
     cloudprotocol::AlertVariant CreateSystemQuotaAlertTemplate(const ResourceIdentifier& resourceIdentifier) const;
     cloudprotocol::AlertVariant CreateInstanceQuotaAlertTemplate(
@@ -147,7 +150,7 @@ private:
     AlertProcessorStaticArray                                                            mAlertProcessors;
     StaticMap<StaticString<cInstanceIDLen>, AlertProcessorStaticArray, cMaxNumInstances> mInstanceAlertProcessors;
 
-    mutable StaticAllocator<sizeof(NodeInfo) + sizeof(sm::resourcemanager::NodeConfig)> mAllocator;
+    mutable StaticAllocator<cAllocatorSize> mAllocator;
 };
 
 } // namespace aos::monitoring

--- a/include/aos/common/types.hpp
+++ b/include/aos/common/types.hpp
@@ -732,7 +732,7 @@ struct Host {
  */
 struct DeviceInfo {
     StaticString<cDeviceNameLen>                                  mName;
-    int                                                           mSharedCount {0};
+    size_t                                                        mSharedCount {0};
     StaticArray<StaticString<cGroupNameLen>, cMaxNumGroups>       mGroups;
     StaticArray<StaticString<cDeviceNameLen>, cMaxNumHostDevices> mHostDevices;
 

--- a/include/aos/iam/nodemanager.hpp
+++ b/include/aos/iam/nodemanager.hpp
@@ -213,6 +213,8 @@ public:
 
 private:
     static constexpr auto cNodeMaxNum = AOS_CONFIG_NODEMANAGER_NODE_MAX_NUM;
+    static constexpr auto cAllocatorSize
+        = sizeof(StaticArray<StaticString<cNodeIDLen>, cNodeMaxNum>) + sizeof(NodeInfo);
 
     NodeInfo*       GetNodeFromCache(const String& nodeID);
     const NodeInfo* GetNodeFromCache(const String& nodeID) const;
@@ -227,6 +229,8 @@ private:
     NodeInfoListenerItf*               mNodeInfoListener = nullptr;
     StaticArray<NodeInfo, cNodeMaxNum> mNodeInfoCache;
     mutable Mutex                      mMutex;
+
+    StaticAllocator<cAllocatorSize> mAllocator;
 };
 
 /** @}*/

--- a/include/aos/iam/permhandler.hpp
+++ b/include/aos/iam/permhandler.hpp
@@ -32,6 +32,21 @@ struct InstancePermissions {
     StaticString<cSecretLen>                                      mSecret;
     InstanceIdent                                                 mInstanceIdent;
     StaticArray<FunctionServicePermissions, cFuncServiceMaxCount> mFuncServicePerms;
+
+    /**
+     * Creates instance permissions.
+     *
+     * @param secret secret.
+     * @param instanceIdent instance ident.
+     * @param funcServicePerms functional service permissions.
+     */
+    InstancePermissions(const String& secret, const InstanceIdent& instanceIdent,
+        const Array<FunctionServicePermissions>& funcServicePerms)
+        : mSecret(secret)
+        , mInstanceIdent(instanceIdent)
+        , mFuncServicePerms(funcServicePerms)
+    {
+    }
 };
 
 /**

--- a/include/aos/sm/launcher.hpp
+++ b/include/aos/sm/launcher.hpp
@@ -98,6 +98,18 @@ public:
     StaticString<cInstanceIDLen> mInstanceID;
 
     /**
+     * Creates instance data.
+     *
+     * @param info instance info.
+     * @param instanceID instance ID.
+     */
+    InstanceData(const InstanceInfo& info, const String& instanceID)
+        : mInstanceInfo(info)
+        , mInstanceID(instanceID)
+    {
+    }
+
+    /**
      * Compares instance data.
      *
      * @param data instance data to compare.
@@ -382,7 +394,7 @@ private:
 
     mutable StaticAllocator<sizeof(InstanceInfoStaticArray) + sizeof(InstanceDataStaticArray) * 2
         + sizeof(ServiceInfoStaticArray) + sizeof(LayerInfoStaticArray) + sizeof(servicemanager::ServiceDataStaticArray)
-        + sizeof(InstanceStatusStaticArray) + sizeof(servicemanager::ServiceData)>
+        + sizeof(InstanceStatusStaticArray) + sizeof(servicemanager::ServiceData) + sizeof(InstanceData)>
         mAllocator;
 
     bool                                      mLaunchInProgress = false;

--- a/include/aos/sm/layermanager.hpp
+++ b/include/aos/sm/layermanager.hpp
@@ -232,6 +232,9 @@ public:
 private:
     static constexpr auto cLayerOCIDescriptor = "layer.json";
     static constexpr auto cNumInstallThreads  = AOS_CONFIG_SERVICEMANAGER_NUM_COOPERATE_INSTALLS;
+    static constexpr auto cAllocatorSize
+        = Max(cNumInstallThreads * sizeof(oci::ImageManifest) + sizeof(LayerDataStaticArray),
+            sizeof(LayerDataStaticArray) + sizeof(FS::DirIterator) * 2);
 
     Error RemoveDamagedLayerFolders();
     Error SetOutdatedLayers();
@@ -250,7 +253,7 @@ private:
     Mutex                              mMutex;
     Timer                              mTimer;
 
-    StaticAllocator<cNumInstallThreads * sizeof(oci::ImageManifest) + 2 * sizeof(LayerDataStaticArray)> mAllocator;
+    StaticAllocator<cAllocatorSize> mAllocator;
 
     ThreadPool<cNumInstallThreads, cMaxNumLayers> mInstallPool;
 };

--- a/include/aos/sm/resourcemanager.hpp
+++ b/include/aos/sm/resourcemanager.hpp
@@ -376,6 +376,8 @@ public:
 
 private:
     static constexpr auto cMaxNodeConfigChangeSubscribers = 2;
+    static constexpr auto cAllocatorSize = Max(sizeof(StaticString<cNodeConfigJSONLen>) + sizeof(NodeConfig),
+        sizeof(DeviceInfo) + sizeof(StaticArray<StaticString<cInstanceIDLen>, cMaxNumInstances>));
 
     Error LoadConfig();
     Error WriteConfig(const NodeConfig& config);
@@ -396,7 +398,7 @@ private:
         cMaxNumNodeDevices>
         mAllocatedDevices;
 
-    mutable StaticAllocator<sizeof(StaticString<cNodeConfigJSONLen>) + sizeof(NodeConfig)> mAllocator;
+    mutable StaticAllocator<cAllocatorSize> mAllocator;
 };
 
 } // namespace aos::sm::resourcemanager

--- a/include/aos/sm/servicemanager.hpp
+++ b/include/aos/sm/servicemanager.hpp
@@ -362,7 +362,7 @@ private:
     Mutex                              mMutex;
 
     StaticAllocator<2 * sizeof(ServiceDataStaticArray) + sizeof(ServiceInfoStaticArray)
-            + cNumInstallThreads * sizeof(oci::ImageManifest),
+            + cNumInstallThreads * (sizeof(oci::ImageManifest) + sizeof(ServiceData)),
         cNumInstallThreads * 3>
         mAllocator;
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -105,6 +105,7 @@ if(WITH_MBEDTLS)
     target_link_libraries(${TARGET} PUBLIC mbedcrypto mbedx509 mbedtls)
 endif()
 
+target_compile_options(${TARGET} PRIVATE -Wstack-usage=${AOS_STACK_USAGE})
 target_include_directories(${TARGET} PUBLIC ${AOS_CORE_LIB_DIR}/include ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 # ######################################################################################################################

--- a/src/iam/CMakeLists.txt
+++ b/src/iam/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SOURCES
 
 add_library(${TARGET} STATIC ${SOURCES})
 
+target_compile_options(${TARGET} PRIVATE -Wstack-usage=${AOS_STACK_USAGE})
 target_include_directories(${TARGET} PUBLIC ${AOS_CORE_LIB_DIR}/include)
 
 # ######################################################################################################################

--- a/src/iam/nodemanager/nodemanager.cpp
+++ b/src/iam/nodemanager/nodemanager.cpp
@@ -22,22 +22,22 @@ Error NodeManager::Init(NodeInfoStorageItf& storage)
 
     mStorage = &storage;
 
-    StaticArray<StaticString<cNodeIDLen>, cNodeMaxNum> nodeIDs;
+    auto nodeIDs = MakeUnique<StaticArray<StaticString<cNodeIDLen>, cNodeMaxNum>>(&mAllocator);
 
-    auto err = storage.GetAllNodeIds(nodeIDs);
+    auto err = storage.GetAllNodeIds(*nodeIDs);
     if (!err.IsNone()) {
         return err;
     }
 
-    for (const auto& nodeID : nodeIDs) {
-        NodeInfo nodeInfo;
+    for (const auto& nodeID : *nodeIDs) {
+        auto nodeInfo = MakeUnique<NodeInfo>(&mAllocator);
 
-        err = storage.GetNodeInfo(nodeID, nodeInfo);
+        err = storage.GetNodeInfo(nodeID, *nodeInfo);
         if (!err.IsNone()) {
             return err;
         }
 
-        err = mNodeInfoCache.PushBack(nodeInfo);
+        err = mNodeInfoCache.PushBack(*nodeInfo);
         if (!err.IsNone()) {
             return err;
         }
@@ -67,8 +67,7 @@ Error NodeManager::SetNodeStatus(const String& nodeID, NodeStatus status)
 
     LOG_DBG() << "Set node status: nodeID=" << nodeID << ", status=" << status;
 
-    NodeInfo nodeInfo {};
-
+    auto nodeInfo   = MakeUnique<NodeInfo>(&mAllocator);
     auto cachedInfo = GetNodeFromCache(nodeID);
 
     if (cachedInfo != nullptr) {
@@ -76,13 +75,13 @@ Error NodeManager::SetNodeStatus(const String& nodeID, NodeStatus status)
             return ErrorEnum::eNone;
         }
 
-        nodeInfo = *cachedInfo;
+        *nodeInfo = *cachedInfo;
     }
 
-    nodeInfo.mNodeID = nodeID;
-    nodeInfo.mStatus = status;
+    nodeInfo->mNodeID = nodeID;
+    nodeInfo->mStatus = status;
 
-    return UpdateNodeInfo(nodeInfo);
+    return UpdateNodeInfo(*nodeInfo);
 }
 
 Error NodeManager::GetNodeInfo(const String& nodeID, NodeInfo& nodeInfo) const

--- a/src/iam/permhandler/permhandler.cpp
+++ b/src/iam/permhandler/permhandler.cpp
@@ -90,7 +90,7 @@ Error PermHandler::GetPermissions(const String& secret, const String& funcServer
 Error PermHandler::AddSecret(const String& secret, const InstanceIdent& instanceIdent,
     const Array<FunctionServicePermissions>& instancePermissions)
 {
-    const auto err = mInstancesPerms.PushBack(InstancePermissions {secret, instanceIdent, instancePermissions});
+    const auto err = mInstancesPerms.EmplaceBack(secret, instanceIdent, instancePermissions);
     if (!err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }

--- a/src/sm/CMakeLists.txt
+++ b/src/sm/CMakeLists.txt
@@ -27,9 +27,10 @@ set(SOURCES
 # ######################################################################################################################
 
 add_library(${TARGET} STATIC ${SOURCES})
-target_link_libraries(${TARGET} PRIVATE aoscommon)
 
+target_compile_options(${TARGET} PRIVATE -Wstack-usage=${AOS_STACK_USAGE})
 target_include_directories(${TARGET} PUBLIC ${AOS_CORE_LIB_DIR}/include)
+target_link_libraries(${TARGET} PRIVATE aoscommon)
 
 # ######################################################################################################################
 # Install

--- a/src/sm/layermanager/layermanager.cpp
+++ b/src/sm/layermanager/layermanager.cpp
@@ -239,15 +239,18 @@ Error LayerManager::RemoveDamagedLayerFolders()
         }
     }
 
-    for (auto layerDirIterator = FS::DirIterator(mConfig.mLayersDir); layerDirIterator.Next();) {
-        if (!layerDirIterator->mIsDir) {
+    auto layerDirIterator = MakeUnique<FS::DirIterator>(&mAllocator, mConfig.mLayersDir);
+
+    while (layerDirIterator->Next()) {
+        if (!(*layerDirIterator)->mIsDir) {
             continue;
         }
 
-        const auto algorithmPath = FS::JoinPath(mConfig.mLayersDir, layerDirIterator->mPath);
+        const auto algorithmPath             = FS::JoinPath(mConfig.mLayersDir, (*layerDirIterator)->mPath);
+        auto       layerAlgorithmDirIterator = MakeUnique<FS::DirIterator>(&mAllocator, algorithmPath);
 
-        for (auto layerAlgorithmDirIterator = FS::DirIterator(algorithmPath); layerAlgorithmDirIterator.Next();) {
-            const auto layerPath = FS::JoinPath(algorithmPath, layerAlgorithmDirIterator->mPath);
+        while (layerAlgorithmDirIterator->Next()) {
+            const auto layerPath = FS::JoinPath(algorithmPath, (*layerAlgorithmDirIterator)->mPath);
 
             const auto it = layers->FindIf([&layerPath](const auto& layer) { return layer.mPath == layerPath; });
             if (it == layers->end()) {


### PR DESCRIPTION
* add stack-usage warning for 4096 byte of stack;
* use space allocator for bit stack data;
* use emplace container api to reduce stack usage.