### PR TITLE
Rename structs for clarity in network

### DIFF
--- a/include/aos/sm/launcher/instance.hpp
+++ b/include/aos/sm/launcher/instance.hpp
@@ -313,7 +313,7 @@ private:
     static constexpr auto cRuntimeDir = AOS_CONFIG_LAUNCHER_RUNTIME_DIR;
     static constexpr auto cAllocatorSize
         = (sizeof(oci::RuntimeSpec) + sizeof(image::ImageParts)
-              + Max(sizeof(networkmanager::NetworkParams), sizeof(monitoring::InstanceMonitorParams),
+              + Max(sizeof(networkmanager::InstanceNetworkParameters), sizeof(monitoring::InstanceMonitorParams),
                   sizeof(oci::ImageSpec) + sizeof(oci::ServiceConfig)
                       + sizeof(StaticArray<StaticString<cEnvVarNameLen>, cMaxNumEnvVariables>),
                   sizeof(LayersStaticArray) + sizeof(layermanager::LayerData), sizeof(Mount) + sizeof(ResourceInfo),

--- a/include/aos/sm/networkmanager.hpp
+++ b/include/aos/sm/networkmanager.hpp
@@ -46,9 +46,9 @@ static constexpr auto cExposedPortLen = cPortLen + cProtocolNameLen;
 static constexpr auto cMaxNumHosts = AOS_CONFIG_NETWORKMANAGER_MAX_NUM_HOSTS;
 
 /**
- * Network parameters set for service provider.
+ * Network information.
  */
-struct NetworkParameters {
+struct NetworkInfo {
     StaticString<cHostNameLen> mNetworkID;
     StaticString<cIPLen>       mSubnet;
     StaticString<cIPLen>       mIP;
@@ -56,68 +56,24 @@ struct NetworkParameters {
     StaticString<cHostNameLen> mVlanIfName;
 
     /**
-     * Compares network parameters.
+     * Compares network information.
      *
-     * @param networkParams network parameters to compare.
+     * @param networkInfo network information to compare.
      * @return bool.
      */
-    bool operator==(const NetworkParameters& networkParams) const
+    bool operator==(const NetworkInfo& networkInfo) const
     {
-        return mNetworkID == networkParams.mNetworkID && mSubnet == networkParams.mSubnet && mIP == networkParams.mIP
-            && mVlanID == networkParams.mVlanID && mVlanIfName == networkParams.mVlanIfName;
+        return mNetworkID == networkInfo.mNetworkID && mSubnet == networkInfo.mSubnet && mIP == networkInfo.mIP
+            && mVlanID == networkInfo.mVlanID && mVlanIfName == networkInfo.mVlanIfName;
     }
 
     /**
-     * Compares network parameters.
+     * Compares network information.
      *
-     * @param networkParams network parameters to compare.
+     * @param networkInfo network information to compare.
      * @return bool.
      */
-    bool operator!=(const NetworkParameters& networkParams) const { return !operator==(networkParams); }
-};
-
-/**
- * Network parameters set for instance.
- */
-struct NetworkParams {
-    InstanceIdent                                                   mInstanceIdent;
-    aos::NetworkParameters                                          mNetworkParameters;
-    StaticString<cHostNameLen>                                      mHostname;
-    StaticArray<StaticString<cHostNameLen>, cMaxNumAliases>         mAliases;
-    uint64_t                                                        mIngressKbit;
-    uint64_t                                                        mEgressKbit;
-    StaticArray<StaticString<cExposedPortLen>, cMaxNumExposedPorts> mExposedPorts;
-    StaticArray<Host, cMaxNumHosts>                                 mHosts;
-    StaticArray<StaticString<cIPLen>, cMaxNumDNSServers>            mDNSSevers;
-    StaticString<cFilePathLen>                                      mHostsFilePath;
-    StaticString<cFilePathLen>                                      mResolvConfFilePath;
-    uint64_t                                                        mUploadLimit;
-    uint64_t                                                        mDownloadLimit;
-
-    /**
-     * Compares network parameters.
-     *
-     * @param networkParams network parameters to compare.
-     * @return bool.
-     */
-    bool operator==(const NetworkParams& networkParams) const
-    {
-        return mInstanceIdent == networkParams.mInstanceIdent && mNetworkParameters == networkParams.mNetworkParameters
-            && mHostname == networkParams.mHostname && mAliases == networkParams.mAliases
-            && mIngressKbit == networkParams.mIngressKbit && mEgressKbit == networkParams.mEgressKbit
-            && mExposedPorts == networkParams.mExposedPorts && mHosts == networkParams.mHosts
-            && mDNSSevers == networkParams.mDNSSevers && mHostsFilePath == networkParams.mHostsFilePath
-            && mResolvConfFilePath == networkParams.mResolvConfFilePath && mUploadLimit == networkParams.mUploadLimit
-            && mDownloadLimit == networkParams.mDownloadLimit;
-    }
-
-    /**
-     * Compares network parameters.
-     *
-     * @param networkParams network parameters to compare.
-     * @return bool.
-     */
-    bool operator!=(const NetworkParams& networkParams) const { return !operator==(networkParams); }
+    bool operator!=(const NetworkInfo& networkInfo) const { return !operator==(networkInfo); }
 };
 
 /**
@@ -136,10 +92,10 @@ public:
     /**
      * Adds network info to storage.
      *
-     * @param info network info.
+     * @param info network information.
      * @return Error.
      */
-    virtual Error AddNetworkInfo(const NetworkParameters& info) = 0;
+    virtual Error AddNetworkInfo(const NetworkInfo& info) = 0;
 
     /**
      * Returns network information.
@@ -147,7 +103,7 @@ public:
      * @param networks[out] network information result.
      * @return Error.
      */
-    virtual Error GetNetworksInfo(Array<NetworkParameters>& networks) const = 0;
+    virtual Error GetNetworksInfo(Array<NetworkInfo>& networks) const = 0;
 
     /**
      * Sets traffic monitor data.
@@ -202,6 +158,55 @@ using TrafficPeriodEnum = TrafficPeriodType::Enum;
 using TrafficPeriod     = EnumStringer<TrafficPeriodType>;
 
 /**
+ * Instance network parameters.
+ */
+struct InstanceNetworkParameters {
+    InstanceIdent                                                   mInstanceIdent;
+    aos::NetworkParameters                                          mNetworkParameters;
+    StaticString<cHostNameLen>                                      mHostname;
+    StaticArray<StaticString<cHostNameLen>, cMaxNumAliases>         mAliases;
+    uint64_t                                                        mIngressKbit;
+    uint64_t                                                        mEgressKbit;
+    StaticArray<StaticString<cExposedPortLen>, cMaxNumExposedPorts> mExposedPorts;
+    StaticArray<Host, cMaxNumHosts>                                 mHosts;
+    StaticArray<StaticString<cIPLen>, cMaxNumDNSServers>            mDNSSevers;
+    StaticString<cFilePathLen>                                      mHostsFilePath;
+    StaticString<cFilePathLen>                                      mResolvConfFilePath;
+    uint64_t                                                        mUploadLimit;
+    uint64_t                                                        mDownloadLimit;
+
+    /**
+     * Compares network parameters.
+     *
+     * @param instanceNetworkParams instance network parameters to compare.
+     * @return bool.
+     */
+    bool operator==(const InstanceNetworkParameters& instanceNetworkParams) const
+    {
+        return mInstanceIdent == instanceNetworkParams.mInstanceIdent
+            && mNetworkParameters == instanceNetworkParams.mNetworkParameters
+            && mHostname == instanceNetworkParams.mHostname && mAliases == instanceNetworkParams.mAliases
+            && mIngressKbit == instanceNetworkParams.mIngressKbit && mEgressKbit == instanceNetworkParams.mEgressKbit
+            && mExposedPorts == instanceNetworkParams.mExposedPorts && mHosts == instanceNetworkParams.mHosts
+            && mDNSSevers == instanceNetworkParams.mDNSSevers && mHostsFilePath == instanceNetworkParams.mHostsFilePath
+            && mResolvConfFilePath == instanceNetworkParams.mResolvConfFilePath
+            && mUploadLimit == instanceNetworkParams.mUploadLimit
+            && mDownloadLimit == instanceNetworkParams.mDownloadLimit;
+    }
+
+    /**
+     * Compares instance network parameters.
+     *
+     * @param instanceNetworkParameters instance network parameters to compare.
+     * @return bool.
+     */
+    bool operator!=(const InstanceNetworkParameters& instanceNetworkParameters) const
+    {
+        return !operator==(instanceNetworkParameters);
+    }
+};
+
+/**
  * Network manager interface.
  */
 class NetworkManagerItf {
@@ -232,10 +237,11 @@ public:
      *
      * @param instanceID instance id.
      * @param networkID network id.
-     * @param network network parameters.
+     * @param instanceNetworkParameters instance network parameters.
      * @return Error.
      */
-    virtual Error AddInstanceToNetwork(const String& instanceID, const String& networkID, const NetworkParams& network)
+    virtual Error AddInstanceToNetwork(
+        const String& instanceID, const String& networkID, const InstanceNetworkParameters& instanceNetworkParameters)
         = 0;
 
     /**
@@ -484,11 +490,11 @@ public:
      *
      * @param instanceID instance ID.
      * @param networkID network ID.
-     * @param network network parameters.
+     * @param instanceNetworkParameters instance network parameters.
      * @return Error.
      */
-    Error AddInstanceToNetwork(
-        const String& instanceID, const String& networkID, const NetworkParams& network) override;
+    Error AddInstanceToNetwork(const String& instanceID, const String& networkID,
+        const InstanceNetworkParameters& instanceNetworkParameters) override;
 
     /**
      * Removes instance from network.
@@ -554,40 +560,41 @@ private:
 
     Error IsInstanceInNetwork(const String& instanceID, const String& networkID) const;
     Error AddInstanceToCache(const String& instanceID, const String& networkID);
-    Error PrepareCNIConfig(const String& instanceID, const String& networkID, const NetworkParams& network,
+    Error PrepareCNIConfig(const String& instanceID, const String& networkID, const InstanceNetworkParameters& network,
         cni::NetworkConfigList& net, cni::RuntimeConf& rt, Array<StaticString<cHostNameLen>>& hosts) const;
-    Error PrepareNetworkConfigList(const String& instanceID, const String& networkID, const NetworkParams& network,
-        cni::NetworkConfigList& net) const;
+    Error PrepareNetworkConfigList(const String& instanceID, const String& networkID,
+        const InstanceNetworkParameters& network, cni::NetworkConfigList& net) const;
     Error PrepareRuntimeConfig(
         const String& instanceID, cni::RuntimeConf& rt, const Array<StaticString<cHostNameLen>>& hosts) const;
 
     Error CreateBridgePluginConfig(
-        const String& networkID, const NetworkParams& network, cni::BridgePluginConf& config) const;
+        const String& networkID, const InstanceNetworkParameters& network, cni::BridgePluginConf& config) const;
     Error CreateFirewallPluginConfig(
-        const String& instanceID, const NetworkParams& network, cni::FirewallPluginConf& config) const;
-    Error CreateBandwidthPluginConfig(const NetworkParams& network, cni::BandwidthNetConf& config) const;
+        const String& instanceID, const InstanceNetworkParameters& network, cni::FirewallPluginConf& config) const;
+    Error CreateBandwidthPluginConfig(const InstanceNetworkParameters& network, cni::BandwidthNetConf& config) const;
     Error CreateDNSPluginConfig(
-        const String& networkID, const NetworkParams& network, cni::DNSPluginConf& config) const;
+        const String& networkID, const InstanceNetworkParameters& network, cni::DNSPluginConf& config) const;
     Error UpdateInstanceNetworkCache(const String& instanceID, const String& networkID, const String& instanceIP,
         const Array<StaticString<cHostNameLen>>& hosts);
     Error RemoveInstanceFromCache(const String& instanceID, const String& networkID);
     Error ClearNetwork(const String& networkID);
-    Error PrepareHosts(const String& instanceID, const String& networkID, const NetworkParams& network,
+    Error PrepareHosts(const String& instanceID, const String& networkID, const InstanceNetworkParameters& network,
         Array<StaticString<cHostNameLen>>& hosts) const;
     Error IsHostnameExist(const InstanceCache& instanceCache, const Array<StaticString<cHostNameLen>>& hosts) const;
     Error PushHostWithDomain(
         const String& host, const String& networkID, Array<StaticString<cHostNameLen>>& hosts) const;
-    Error CreateHostsFile(const String& networkID, const String& instanceIP, const NetworkParams& network) const;
+    Error CreateHostsFile(
+        const String& networkID, const String& instanceIP, const InstanceNetworkParameters& network) const;
     Error WriteHost(const Host& host, int fd) const;
     Error WriteHosts(Array<SharedPtr<Host>> hosts, int fd) const;
     Error WriteHosts(Array<Host> hosts, int fd) const;
     Error WriteHostsFile(
-        const String& filePath, const Array<SharedPtr<Host>>& hosts, const NetworkParams& network) const;
+        const String& filePath, const Array<SharedPtr<Host>>& hosts, const InstanceNetworkParameters& network) const;
 
-    Error CreateResolvConfFile(
-        const String& networkID, const NetworkParams& network, const Array<StaticString<cIPLen>>& dns) const;
-    Error WriteResolvConfFile(
-        const String& filePath, const Array<StaticString<cIPLen>>& mainServers, const NetworkParams& network) const;
+    Error CreateResolvConfFile(const String& networkID, const InstanceNetworkParameters& network,
+        const Array<StaticString<cIPLen>>& dns) const;
+    Error WriteResolvConfFile(const String& filePath, const Array<StaticString<cIPLen>>& mainServers,
+        const InstanceNetworkParameters& network) const;
 
     StorageItf*                 mStorage {};
     cni::CNIItf*                mCNI {};

--- a/src/sm/launcher/instance.cpp
+++ b/src/sm/launcher/instance.cpp
@@ -635,7 +635,7 @@ Error Instance::SetupNetwork(const oci::ServiceConfig& serviceConfig)
 {
     LOG_DBG() << "Setup network: instanceID=" << *this;
 
-    auto networkParams = MakeUnique<networkmanager::NetworkParams>(&sAllocator);
+    auto networkParams = MakeUnique<networkmanager::InstanceNetworkParameters>(&sAllocator);
 
     networkParams->mInstanceIdent      = mInstanceInfo.mInstanceIdent;
     networkParams->mHostsFilePath      = FS::JoinPath(mRuntimeDir, cMountPointsDir, "etc", "hosts");

--- a/tests/include/mocks/networkmanagermock.hpp
+++ b/tests/include/mocks/networkmanagermock.hpp
@@ -16,8 +16,8 @@ namespace aos::sm::networkmanager {
 class StorageMock : public StorageItf {
 public:
     MOCK_METHOD(Error, RemoveNetworkInfo, (const String& networkID), (override));
-    MOCK_METHOD(Error, AddNetworkInfo, (const NetworkParameters& info), (override));
-    MOCK_METHOD(Error, GetNetworksInfo, (Array<NetworkParameters> & networks), (const, override));
+    MOCK_METHOD(Error, AddNetworkInfo, (const NetworkInfo& info), (override));
+    MOCK_METHOD(Error, GetNetworksInfo, (Array<NetworkInfo> & networks), (const, override));
     MOCK_METHOD(Error, SetTrafficMonitorData, (const String& chain, const Time& time, uint64_t value), (override));
     MOCK_METHOD(Error, GetTrafficMonitorData, (const String& chain, Time& time, uint64_t& value), (const, override));
     MOCK_METHOD(Error, RemoveTrafficMonitorData, (const String& chain), (override));
@@ -41,7 +41,8 @@ public:
     MOCK_METHOD(RetWithError<StaticString<cFilePathLen>>, GetNetnsPath, (const String& instanceID), (const, override));
     MOCK_METHOD(Error, UpdateNetworks, (const Array<aos::NetworkParameters>& networks), (override));
     MOCK_METHOD(Error, AddInstanceToNetwork,
-        (const String& instanceID, const String& networkID, const NetworkParams& network), (override));
+        (const String& instanceID, const String& networkID, const InstanceNetworkParameters& instanceNetworkParameters),
+        (override));
     MOCK_METHOD(Error, RemoveInstanceFromNetwork, (const String& instanceID, const String& networkID), (override));
     MOCK_METHOD(
         Error, GetInstanceIP, (const String& instanceID, const String& networkID, String& ip), (const, override));

--- a/tests/sm/networkmanager/networkmanager_test.cpp
+++ b/tests/sm/networkmanager/networkmanager_test.cpp
@@ -45,9 +45,9 @@ protected:
         std::filesystem::remove_all(mWorkingDir.CStr());
     }
 
-    NetworkParams CreateTestNetworkParams()
+    InstanceNetworkParameters CreateTestInstanceNetworkParameters()
     {
-        NetworkParams params;
+        InstanceNetworkParameters params;
         params.mInstanceIdent.mServiceID  = "test-service";
         params.mInstanceIdent.mSubjectID  = "test-subject";
         params.mInstanceIdent.mInstance   = 0;
@@ -93,7 +93,7 @@ TEST_F(NetworkManagerTest, AddInstanceToNetwork_VerifyHostsFile)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     params.mHostsFilePath = aos::FS::JoinPath(mWorkingDir, "hosts");
 
@@ -139,7 +139,7 @@ TEST_F(NetworkManagerTest, AddInstanceToNetwork_ValidateAllPluginConfigs)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     params.mNetworkParameters.mIP     = "192.168.1.2";
     params.mNetworkParameters.mSubnet = "192.168.1.0/24";
@@ -248,7 +248,7 @@ TEST_F(NetworkManagerTest, AddInstanceToNetwork_VerifyResolvConfFile)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     params.mResolvConfFilePath = aos::FS::JoinPath(mWorkingDir, "resolv.conf");
 
@@ -281,7 +281,7 @@ TEST_F(NetworkManagerTest, AddInstanceToNetwork_NoConfigFiles)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     params.mHostsFilePath      = "";
     params.mResolvConfFilePath = "";
@@ -308,7 +308,7 @@ TEST_F(NetworkManagerTest, AddInstanceToNetwork_FileCreationError)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     params.mHostsFilePath      = "/nonexistent/directory/hosts";
     params.mResolvConfFilePath = "/nonexistent/directory/resolv.conf";
@@ -335,7 +335,7 @@ TEST_F(NetworkManagerTest, AddInstanceToNetwork_FailOnCNIError)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     EXPECT_CALL(mCNI, AddNetworkList(_, _, _)).WillOnce(Return(aos::ErrorEnum::eInvalidArgument));
 
@@ -352,7 +352,7 @@ TEST_F(NetworkManagerTest, AddInstanceToNetwork_FailOnTrafficMonitorError)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     Result cniResult;
     cniResult.mDNSServers.PushBack("8.8.8.8");
@@ -378,7 +378,7 @@ TEST_F(NetworkManagerTest, AddInstanceToNetwork_DuplicateInstance)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     Result cniResult;
     cniResult.mDNSServers.PushBack("8.8.8.8");
@@ -400,7 +400,7 @@ TEST_F(NetworkManagerTest, RemoveInstanceFromNetwork)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     Result cniResult;
     cniResult.mDNSServers.PushBack("8.8.8.8");
@@ -437,7 +437,7 @@ TEST_F(NetworkManagerTest, RemoveInstanceFromNetwork_MultipleInstances)
     const aos::String instanceID1 = "test-instance-1";
     const aos::String instanceID2 = "test-instance-2";
     const aos::String networkID   = "test-network";
-    auto              params      = CreateTestNetworkParams();
+    auto              params      = CreateTestInstanceNetworkParameters();
 
     Result cniResult;
     cniResult.mDNSServers.PushBack("8.8.8.8");
@@ -486,7 +486,7 @@ TEST_F(NetworkManagerTest, RemoveInstanceFromNetwork_AddRemovedInstance)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     Result cniResult;
     cniResult.mDNSServers.PushBack("8.8.8.8");
@@ -521,7 +521,7 @@ TEST_F(NetworkManagerTest, RemoveInstanceFromNetwork_FailOnCNIError)
 {
     const aos::String instanceID = "test-instance";
     const aos::String networkID  = "test-network";
-    auto              params     = CreateTestNetworkParams();
+    auto              params     = CreateTestInstanceNetworkParameters();
 
     Result cniResult;
     cniResult.mDNSServers.PushBack("8.8.8.8");


### PR DESCRIPTION
Renamed structs like `NetworkParams` and `NetworkParameters` to improve clarity and avoid conflicts in the same namespace.