### PR TITLE
[layermanager] Allocate  layer data on static allocator

### DIFF
--- a/include/aos/sm/layermanager.hpp
+++ b/include/aos/sm/layermanager.hpp
@@ -233,7 +233,7 @@ private:
     static constexpr auto cLayerOCIDescriptor = "layer.json";
     static constexpr auto cNumInstallThreads  = AOS_CONFIG_SERVICEMANAGER_NUM_COOPERATE_INSTALLS;
     static constexpr auto cAllocatorSize
-        = Max(cNumInstallThreads * sizeof(oci::ImageManifest) + sizeof(LayerDataStaticArray),
+        = Max(cNumInstallThreads * (sizeof(oci::ImageManifest) + sizeof(LayerData)) + sizeof(LayerDataStaticArray),
             sizeof(LayerDataStaticArray) + sizeof(FS::DirIterator) * 2);
 
     Error RemoveDamagedLayerFolders();

--- a/src/sm/layermanager/layermanager.cpp
+++ b/src/sm/layermanager/layermanager.cpp
@@ -448,14 +448,15 @@ Error LayerManager::InstallLayer(const LayerInfo& layer)
         return AOS_ERROR_WRAP(err);
     }
 
-    const auto layerData = CreateLayerData(layer, unpackedSpace->Size(), storeLayerPath);
+    auto layerData = MakeUnique<LayerData>(&mAllocator);
+    *layerData     = CreateLayerData(layer, unpackedSpace->Size(), storeLayerPath);
 
-    if (err = mStorage->AddLayer(layerData); !err.IsNone()) {
+    if (err = mStorage->AddLayer(*layerData); !err.IsNone()) {
         return AOS_ERROR_WRAP(err);
     }
 
-    LOG_INF() << "Layer successfully installed: id=" << layerData.mLayerID << ", version=" << layerData.mVersion
-              << ", digest=" << layerData.mLayerDigest;
+    LOG_INF() << "Layer successfully installed: id=" << layerData->mLayerID << ", version=" << layerData->mVersion
+              << ", digest=" << layerData->mLayerDigest;
 
     return ErrorEnum::eNone;
 }


### PR DESCRIPTION
This patch reduces stack usage for aos-vm-dev build

```
layermanager.cpp:404:7: error: stack usage is 4416 bytes [-Werror=stack-usage=]
  404 | Error LayerManager::InstallLayer(const LayerInfo& layer)
      |       ^~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```