### PR TITLE
[sm,servicemanager] Remove damaged services on initialization

### DIFF
--- a/src/sm/servicemanager/servicemanager.cpp
+++ b/src/sm/servicemanager/servicemanager.cpp
@@ -350,7 +350,7 @@ Error ServiceManager::RemoveDamagedServiceFolders(const Array<ServiceData>& serv
         const auto fullPath = FS::JoinPath(mConfig.mServicesDir, serviceDirIterator->mPath);
 
         if (services.FindIf([&fullPath](const ServiceData& service) { return service.mImagePath == fullPath; })
-            == services.end()) {
+            != services.end()) {
             continue;
         }
 


### PR DESCRIPTION
This patch fixes a bug that caused the
service manager to remove undamaged services on initialization.