### PR TITLE
Start instance monitoring before instance is launched

### DIFF
--- a/include/aos/common/monitoring/monitoring.hpp
+++ b/include/aos/common/monitoring/monitoring.hpp
@@ -115,10 +115,11 @@ struct InstanceMonitoringData {
     {
     }
 
-    InstanceIdent  mInstanceIdent  = {};
-    MonitoringData mMonitoringData = {};
-    uint32_t       mUID            = 0;
-    uint32_t       mGID            = 0;
+    InstanceIdent    mInstanceIdent  = {};
+    MonitoringData   mMonitoringData = {};
+    uint32_t         mUID            = 0;
+    uint32_t         mGID            = 0;
+    InstanceRunState mRunState       = InstanceRunStateEnum::eFailed;
 
     /**
      * Compares instance monitoring data.
@@ -232,6 +233,15 @@ public:
      * @return Error.
      */
     virtual Error StartInstanceMonitoring(const String& instanceID, const InstanceMonitorParams& monitoringConfig) = 0;
+
+    /**
+     * Updates instance's run state.
+     *
+     * @param instanceID instance ID.
+     * @param runState run state.
+     * @return Error.
+     */
+    virtual Error UpdateInstanceRunState(const String& instanceID, InstanceRunState runState) = 0;
 
     /**
      * Stops instance monitoring.

--- a/include/aos/common/monitoring/resourcemonitor.hpp
+++ b/include/aos/common/monitoring/resourcemonitor.hpp
@@ -72,6 +72,15 @@ public:
     Error StartInstanceMonitoring(const String& instanceID, const InstanceMonitorParams& monitoringConfig) override;
 
     /**
+     * Updates instance's run state.
+     *
+     * @param instanceID instance ID.
+     * @param runState run state.
+     * @return Error.
+     */
+    Error UpdateInstanceRunState(const String& instanceID, InstanceRunState runState) override;
+
+    /**
      * Stops instance monitoring.
      *
      * @param instanceID instance ID.

--- a/src/common/monitoring/resourcemonitor.cpp
+++ b/src/common/monitoring/resourcemonitor.cpp
@@ -149,7 +149,7 @@ Error ResourceMonitor::StartInstanceMonitoring(const String& instanceID, const I
 
     if (err = mResourceUsageProvider->GetInstanceMonitoringData(
             instanceID, mInstanceMonitoringData.Find(instanceID)->mSecond);
-        !err.IsNone()) {
+        !err.IsNone() && !err.Is(ErrorEnum::eNotFound)) {
         LOG_WRN() << "Can't get instance monitoring data: instanceID=" << instanceID << ", err=" << err;
     }
 

--- a/src/sm/launcher/instance.cpp
+++ b/src/sm/launcher/instance.cpp
@@ -119,6 +119,10 @@ Error Instance::Start()
         return err;
     }
 
+    if (auto err = SetupMonitoring(); !err.IsNone()) {
+        return AOS_ERROR_WRAP(err);
+    }
+
     auto runStatus = mRunner.StartInstance(mInstanceID, mRuntimeDir, {});
 
     mRunState = runStatus.mState;
@@ -127,8 +131,8 @@ Error Instance::Start()
         return AOS_ERROR_WRAP(runStatus.mError);
     }
 
-    if (auto err = SetupMonitoring(); !err.IsNone()) {
-        return err;
+    if (auto err = mResourceMonitor.UpdateInstanceRunState(mInstanceID, mRunState); !err.IsNone()) {
+        return AOS_ERROR_WRAP(err);
     }
 
     return ErrorEnum::eNone;

--- a/tests/include/mocks/monitoringmock.hpp
+++ b/tests/include/mocks/monitoringmock.hpp
@@ -20,6 +20,7 @@ class ResourceMonitorMock : public ResourceMonitorItf {
 public:
     MOCK_METHOD(Error, StartInstanceMonitoring,
         (const String& instanceID, const InstanceMonitorParams& monitoringConfig), (override));
+    MOCK_METHOD(Error, UpdateInstanceRunState, (const String& instanceID, InstanceRunState runState), (override));
     MOCK_METHOD(Error, StopInstanceMonitoring, (const String& instanceID), (override));
     MOCK_METHOD(Error, GetAverageMonitoringData, (NodeMonitoringData & monitoringData), (override));
 };


### PR DESCRIPTION
ResourceMonitor::ProcessMonitoring() runs on a separate thread and operates with a delay defined by the "poll period" configuration variable.

As a result, ProcessMonitoring() may execute at a moment when instance monitoring has started, but the instance itself has not yet been launched, leading to the following error: `main aos_servicemanager[1659]: (monitoring) Failed to get instance monitoring data: not found (resourceusageprovider.cpp:324)`

