### PR TITLE
[common] Increase AOS_CONFIG_TYPES_FS_MOUNT_OPTION_LEN to 64

### DIFF
--- a/include/aos/common/config.hpp
+++ b/include/aos/common/config.hpp
@@ -166,7 +166,7 @@
  * File system mount option len.
  */
 #ifndef AOS_CONFIG_TYPES_FS_MOUNT_OPTION_LEN
-#define AOS_CONFIG_TYPES_FS_MOUNT_OPTION_LEN 16
+#define AOS_CONFIG_TYPES_FS_MOUNT_OPTION_LEN 64
 #endif
 
 /**


### PR DESCRIPTION
We have long mount option for TMP folder, it more than 40 chars. Increase this value up to 64.