### PR TITLE
[sm,launcher] Fix instance static allocator size

### DIFF
--- a/include/aos/sm/launcher/instance.hpp
+++ b/include/aos/sm/launcher/instance.hpp
@@ -310,9 +310,10 @@ private:
     static constexpr auto cAllocatorSize = sizeof(image::ImageParts) + sizeof(oci::ServiceConfig)
         + sizeof(oci::RuntimeSpec)
         + Max(sizeof(networkmanager::InstanceNetworkParameters), sizeof(monitoring::InstanceMonitorParams),
-            sizeof(oci::ImageSpec) + sizeof(EnvVarsArray), sizeof(LayersStaticArray) + sizeof(layermanager::LayerData),
-            sizeof(Mount) + sizeof(ResourceInfo),
-            sizeof(Mount) + sizeof(DeviceInfo) + sizeof(StaticArray<oci::LinuxDevice, cMaxNumHostDevices>));
+            sizeof(oci::ImageSpec)
+                + Max(sizeof(EnvVarsArray), sizeof(LayersStaticArray) + sizeof(layermanager::LayerData),
+                    sizeof(Mount) + sizeof(ResourceInfo),
+                    sizeof(Mount) + sizeof(DeviceInfo) + sizeof(StaticArray<oci::LinuxDevice, cMaxNumHostDevices>)));
     static constexpr auto cNumAllocations  = 8;
     static constexpr auto cRuntimeSpecFile = "config.json";
     static constexpr auto cMountPointsDir  = "mounts";


### PR DESCRIPTION
Instance allocator size wasn't calculated properly: image spec size should be add for each path.