### PR TITLE
[all] Fix CI build for openssl provider implementation

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -48,7 +48,11 @@ jobs:
 
       - name: Build using SonarQube Build Wrapper
         run: |
-          cmake -S . -B build  -DCMAKE_BUILD_TYPE=Debug -DWITH_TEST=ON -DWITH_COVERAGE=ON -G "Unix Makefiles" -DCoverage_SONARQUBE=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          mkdir build
+          conan profile detect --force
+          conan install ./conan/ --output-folder build --settings=build_type=Debug --build=missing
+          cmake -S . -B build  -DCMAKE_TOOLCHAIN_FILE=./conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" \
+            -DCoverage_SONARQUBE=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DWITH_TEST=ON -DWITH_COVERAGE=ON -DWITH_MBEDTLS=ON -DWITH_OPENSSL=ON
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config Debug --parallel
 
       - name: Run Tests

--- a/conan/conanfile.py
+++ b/conan/conanfile.py
@@ -1,0 +1,13 @@
+from conan import ConanFile
+
+class AosCoreLibCpp(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def requirements(self):
+        self.requires("gtest/1.14.0")
+        self.requires("openssl/3.2.1")
+
+    def configure(self):
+        self.options["openssl"].no_dso = False
+        self.options["openssl"].shared = True


### PR DESCRIPTION
Changes to CI should be separated in a dedicated PR due to limitations of workflow's pullrequest target option.