### PR TITLE
[networkmanager] Fix remove network instance

### DIFF
--- a/src/sm/networkmanager/networkmanager.cpp
+++ b/src/sm/networkmanager/networkmanager.cpp
@@ -223,6 +223,12 @@ Error NetworkManager::RemoveInstanceFromNetwork(const String& instanceID, const 
 {
     LOG_DBG() << "Remove instance from network: instanceID=" << instanceID << ", networkID=" << networkID;
 
+    if (!mNetworkProviders.Contains(networkID) && !mNetworkData.Contains(networkID)) {
+        LOG_WRN() << "Network not found" << Log::Field("networkID", networkID);
+
+        return ErrorEnum::eNone;
+    }
+
     if (auto err = IsInstanceInNetwork(instanceID, networkID); !err.IsNone()) {
         return err;
     }


### PR DESCRIPTION
When UpdateNetworks runs first (to delete a network from CM if it has no services), it may completely remove that network from the provider. The subsequent RemoveInstanceFromNetwork call then sees “network not found” and should not throw an error, since the network may already have been deleted.