### PR TITLE
ci: set docker build context to docker

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build and push docker image
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ./docker
           file: ./docker/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/aos-core-build:latest


### PR DESCRIPTION
This patch updates the Docker build context in the GitHub Actions workflow to the docker directory,
so conan subfolder is included in the build context.