### PR TITLE
common: tools: use assign to add split string item

### DIFF
--- a/src/core/common/tools/string.hpp
+++ b/src/core/common/tools/string.hpp
@@ -660,10 +660,21 @@ public:
         auto it     = begin();
         auto prevIt = it;
 
+        auto addElement = [&list](const String& str) -> Error {
+            if (auto err = list.EmplaceBack(); !err.IsNone()) {
+                return err;
+            }
+
+            if (auto err = list.Back().Assign(str); !err.IsNone()) {
+                return err;
+            }
+
+            return ErrorEnum::eNone;
+        };
+
         while (it != end()) {
             if (delim ? *it == delim : isspace(*it)) {
-                auto err = list.PushBack(String(prevIt, it - prevIt));
-                if (!err.IsNone()) {
+                if (auto err = addElement(String(prevIt, it - prevIt)); !err.IsNone()) {
                     return err;
                 }
 
@@ -677,8 +688,7 @@ public:
         }
 
         if (it != prevIt) {
-            auto err = list.PushBack(String(prevIt, it - prevIt));
-            if (!err.IsNone()) {
+            if (auto err = addElement(String(prevIt, it - prevIt)); !err.IsNone()) {
                 return err;
             }
         }

--- a/src/core/common/tools/tests/string.cpp
+++ b/src/core/common/tools/tests/string.cpp
@@ -186,6 +186,16 @@ TEST(StringTest, Split)
     EXPECT_EQ(splitArray, resultArray);
 }
 
+TEST(StringTest, SplittedPieceExceedsDestinationItemSize)
+{
+    constexpr auto cString = "someLongPiece1 someLongPiece2";
+
+    StaticArray<StaticString<2>, 2> splitArray;
+
+    auto err = String(cString).Split(splitArray);
+    EXPECT_EQ(err, ErrorEnum::eNoMemory);
+}
+
 TEST(StringTest, HexToByteArray)
 {
     const String hex = "abcDEF0123456789";

--- a/src/core/sm/image/imageparts.cpp
+++ b/src/core/sm/image/imageparts.cpp
@@ -18,7 +18,7 @@ namespace {
 
 RetWithError<StaticString<cFilePathLen>> DigestToPath(const String& digest)
 {
-    StaticArray<const StaticString<oci::cMaxDigestLen>, 2> digestList;
+    StaticArray<StaticString<oci::cMaxDigestLen>, 2> digestList;
 
     if (auto err = digest.Split(digestList, ':'); !err.IsNone()) {
         return {{}, AOS_ERROR_WRAP(err)};


### PR DESCRIPTION
This patch improves safety of the split function by using emplace back and assign instead of a single push back, to ensure split item size does not exceed the destination item size.